### PR TITLE
simpler "start" command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1\
     PATH=/virtualenv/bin:/root/.local/bin:$PATH\
     PROCFILE_PATH=/app/Procfile
 
-ADD stack /stack
+COPY stack /stack
 RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /stack/prepare
 
 RUN virtualenv --prompt mypython --no-site-packages /virtualenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:2.7.10
 
 ENV PYTHONUNBUFFERED=1\
     PIP_REQUIRE_VIRTUALENV=false\
-    PATH=/virtualenv/bin:/root/.local/bin:$PATH
+    PATH=/virtualenv/bin:/root/.local/bin:$PATH\
+    PROCFILE_PATH=/app/Procfile
 
 ADD stack /stack
 RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /stack/prepare

--- a/stack/prepare
+++ b/stack/prepare
@@ -12,7 +12,6 @@ BASEDIR=$(dirname "$SCRIPT")
 # SYSTEM PACKAGES
 #
 apt-get update
-# IMPORTANT: packages.txt must NOT contain anything that depends on python
 xargs apt-get install -y --force-yes --no-install-recommends < /stack/packages.txt
 apt-get clean
 
@@ -40,9 +39,6 @@ chmod u+x /usr/local/bin/forego
 # cleanup
 rm -rf /var/lib/apt/lists/*
 apt-get clean
-
-# make node available with its default name
-# ln -s /usr/bin/nodejs /usr/bin/node
 
 # workaround for a bug in hub.docker.com
 ln -s -f /bin/true /usr/bin/chfn

--- a/stack/prepare
+++ b/stack/prepare
@@ -28,9 +28,12 @@ curl --silent --retry 5 https://raw.githubusercontent.com/mitsuhiko/pipsi/master
 pipsi install mercurial
 pipsi install pip-tools
 pipsi install supervisor
+pipsi install start
 
 
 # install forego (a foreman clone in go)
+# TODO: remove once not needed anymore. Currently aldryn-django uses forego to
+#       launch pagespeed sites with separate nginx and django processes.
 curl --silent --show-error --retry 5 -o /usr/local/bin/forego https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego
 chmod u+x /usr/local/bin/forego
 
@@ -44,9 +47,7 @@ apt-get clean
 # workaround for a bug in hub.docker.com
 ln -s -f /bin/true /usr/bin/chfn
 
-# copy our custom commands
-cp ${BASEDIR}/start /usr/local/bin/start
-ln -nsf /usr/local/bin/start /start
+# install custom commands
 cp ${BASEDIR}/run-forest-run /usr/local/bin/run-forest-run
 
 # default virtualenv

--- a/stack/start
+++ b/stack/start
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd /app
-exec forego start -f Procfile $1


### PR DESCRIPTION
removes the forego based one, which would add a lot of unnecessary shell
color codes and useless output.

Uses the https://github.com/aldryncore/start package from pypi.
