### PR TITLE
Switch to debian stretch base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.14-stretch
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_REQUIRE_VIRTUALENV=false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM python:2.7.14-stretch
 ENV PYTHONUNBUFFERED=1 \
     PIP_REQUIRE_VIRTUALENV=false \
     WHEELS_PLATFORM=aldryn-baseproject \
-    PATH=/virtualenv/bin:/root/.local/bin:$PATH \
+    PIPSI_HOME=/root/.pipsi/venvs \
+    PIPSI_BIN_DIR=/root/.pipsi/bin \
+    PATH=/virtualenv/bin:/root/.pipsi/bin:$PATH \
     PROCFILE_PATH=/app/Procfile \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6.3-stretch
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_REQUIRE_VIRTUALENV=false \

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,9 +1,11 @@
-FROM python:3.6.3-stretch
+FROM python:3.6.3-slim-stretch
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_REQUIRE_VIRTUALENV=false \
     WHEELS_PLATFORM=aldryn-baseproject-py36 \
-    PATH=/virtualenv/bin:/root/.local/bin:$PATH \
+    PIPSI_HOME=/root/.pipsi/venvs \
+    PIPSI_BIN_DIR=/root/.pipsi/bin \
+    PATH=/virtualenv/bin:/root/.pipsi/bin:$PATH \
     PROCFILE_PATH=/app/Procfile \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2"
+services:
+  py3:
+    build:
+      context: .
+      dockerfile: Dockerfile.py3
+    image: aldryn/base-experimental:py3-latest-slim-stretch
+    volumes:
+      - "./stack:/stack"
+
+  py2:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: aldryn/base-experimental:py2-latest-slim-stretch
+    volumes:
+      - "./stack:/stack"

--- a/stack/install.sh
+++ b/stack/install.sh
@@ -14,7 +14,7 @@ BASEDIR=$(dirname "$SCRIPT")
 # SYSTEM PACKAGES
 #
 # Add postgres repo
-echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' >/etc/apt/sources.list.d/pgdg.list
+echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >/etc/apt/sources.list.d/pgdg.list
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 # Update package listings

--- a/stack/packages.dev.txt
+++ b/stack/packages.dev.txt
@@ -1,0 +1,2 @@
+# All dependencies needed to build wheels for python packages.
+gcc

--- a/stack/packages.min.txt
+++ b/stack/packages.min.txt
@@ -1,0 +1,21 @@
+wget
+curl
+
+# Needed to connect to postgres databases
+postgresql-client-9.6
+
+# For Pillow
+zlib1g
+# Pillow: The prebuilt wheel from pypi expects libtiff to be installed :-(
+libtiff5
+# Pillow: jpeg support
+libjpeg62-turbo
+
+# Required Certificates to avoid SSL errors with python requests and and other http libs.
+ca-certificates
+
+# lxml
+libxslt1.1
+
+# For uwsgi. Must match the dev packages
+libssl1.1

--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -26,12 +26,10 @@ libjpeg62
 libmagickcore-dev
 libmagickwand-dev
 libmcrypt-dev
-libmysqlclient-dev
 libncurses5-dev
 libpcre3
 libpcre3-dev
-libpng12-0
-libpng12-dev
+libpng-dev
 libpq-dev
 libproj-dev
 libreadline-dev
@@ -41,7 +39,6 @@ libxml2-dev
 libxslt-dev
 libyaml-dev
 mercurial
-mysql-client
 netcat-openbsd
 openssh-client
 openssh-server


### PR DESCRIPTION
This to figure out:

- [ ] how should we release this? Do we need a separate release channel and a separate tag name (e.g ``:py3-3.30-stretch``)? Or shall we just make it a regular update on the current release channel.
- [ ] reduce CVEs further (e.g newer version of ImageMagick?)
- [ ] CVE whitelist